### PR TITLE
Add CMD to Dockerfile, add memo to invoice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .next
 node_modules
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,6 @@ RUN yarn build
 
 COPY docker-entrypoint.sh /usr/local/bin/
 
+CMD ["yarn", "start"]
+
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/api/resolvers.js
+++ b/api/resolvers.js
@@ -46,11 +46,11 @@ module.exports = ({ pubsub, lightning }) => ({
     },
   },
   Mutation: {
-    addInvoice: async (root, { amount }, { macaroon, headers }) => {
+    addInvoice: async (root, { amount }, { macaroon, createMemo, headers }) => {
       const meta = new grpc.Metadata()
       meta.add('macaroon', macaroon)
       const addInvoice = util.promisify(lightning.addInvoice.bind(lightning))
-      const response = await addInvoice({ value: amount }, meta)
+      const response = await addInvoice({ value: amount, memo: createMemo(amount) }, meta)
       return {
         r_hash: response.r_hash.toString('hex'),
         payment_request: response.payment_request,

--- a/bin/sweet-lightning
+++ b/bin/sweet-lightning
@@ -31,6 +31,7 @@ program
   .option('--externalurl [url]', 'External url to the web app', process.env.EXTERNAL_URL || 'http://localhost:3000')
   .option('--footer [text]', 'Footer text', process.env.FOOTER || 'the.lightning.land')
   .option('--footer.url [url]', 'Footer url', process.env.FOOTER_URL || 'https://the.lightning.land')
+  .option('--memo.template [text]', 'Template of invoice memo. Use the placeholder $amt for the amount in satoshis.', process.env.MEMO_TEMPLATE || 'Candy for $amt sat')
   .parse(process.argv)
 
 let lndMacaroon
@@ -123,6 +124,10 @@ subscribeToInvoices()
 
 const typeDefsPath = path.join(nextDir, 'schema.graphqls')
 const typeDefs = fs.readFileSync(typeDefsPath, 'utf8')
+const createMemo = (amount) => {
+  const memoTemplate = program['memo.template'];
+  return memoTemplate.replace(/\$amt/g, `${amount}`);
+};
 
 app.prepare().then(() => {
   const schema = makeExecutableSchema({
@@ -138,6 +143,7 @@ app.prepare().then(() => {
     schema,
     context: {
       macaroon: lndMacaroon,
+      createMemo,
     },
   }))
 


### PR DESCRIPTION
There are two notable changes:

* Add CMD to Dockerfile so by default the image can be run without any parameters at all (when passing all options through Env variables for example)
* Add the option `--memo.template` (or Env variable `MEMO_TEMPLATE`) to set the template that is used to add a memo to each invoice. The placeholder `$amt` can be used for the amount of satoshis that the invoice is created for. The default value for the option is `Candy for $amt sat`.

Feel free to tell me if you want the two changes in separate PRs.